### PR TITLE
Explain server component render error

### DIFF
--- a/components/navbar/DropDownMenu.tsx
+++ b/components/navbar/DropDownMenu.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '../ui/dropdown-menu'
 import { LuAlignLeft } from 'react-icons/lu'

--- a/components/navbar/UserIcon.tsx
+++ b/components/navbar/UserIcon.tsx
@@ -1,10 +1,12 @@
-import { currentUser } from '@clerk/nextjs/server'
+'use client'
+
+import { useUser } from '@clerk/nextjs'
 import { LucideUserCircle2 } from 'lucide-react';
 import React from 'react'
 
-async function UserIcon() {
-  const profile = await currentUser();
-  const userImg = profile?.imageUrl
+function UserIcon() {
+  const { user } = useUser();
+  const userImg = user?.imageUrl
 
     if(userImg){
         return (


### PR DESCRIPTION
Convert `DropDownMenu` and `UserIcon` to Client Components to resolve a Server Component render error.

The error occurred because an async Server Component (`UserIcon` using `currentUser()`) was being rendered within a Client Component boundary, leading to hydration issues. Converting these components to Client Components and using Clerk's client-side `useUser()` hook resolves this boundary violation.

---
<a href="https://cursor.com/background-agent?bcId=bc-5cdf41a9-d557-491d-8cbb-d2e5aad36406">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5cdf41a9-d557-491d-8cbb-d2e5aad36406">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>